### PR TITLE
Update headers to support NGINX SSL Proxy

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,8 @@ function keepAlive(res) {
   res.writeHead(200, {
     'Content-Type': 'text/event-stream',
     'Cache-Control': 'no-cache',
-    'Connection': 'keep-alive'
+    'Connection': 'keep-alive',
+    'X-Accel-Buffering': 'no'
   });
 }
 


### PR DESCRIPTION
When SSE connection is proxied through NGINX using SSL, the proxy will buffer responses, delaying (and sometime preventing) the response stream.  This NGINX specific header ensures that streaming HTTP applications work as expected.

https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/